### PR TITLE
Disabling hostname check by default and adding tests

### DIFF
--- a/src/main/java/com/marklogic/mgmt/resource/security/CertificateTemplateManager.java
+++ b/src/main/java/com/marklogic/mgmt/resource/security/CertificateTemplateManager.java
@@ -116,13 +116,22 @@ public class CertificateTemplateManager extends AbstractResourceManager {
 	 *
 	 * Used because ML9.0-5 (and prior) has bug for "needs-certificate" call
 	 */
-	public boolean certificateExists(String templateIdOrName, String certHostName) {
-		Fragment response = getCertificatesForTemplate(templateIdOrName);
-		if (logger.isDebugEnabled()) {
-			logger.debug(format("Checking if %s template has certificates --> for template: %s", templateIdOrName, response.getPrettyXml()));
-		}
+	public boolean certificateExists(String templateIdOrName) {
+		return certificateExists(templateIdOrName, null);
+	}
 
-		return response.elementExists("/msec:certificate-list/msec:certificate[./msec:host-name = '" + certHostName + "']");
+	/**
+	 *
+	 * @param templateIdOrName
+	 * @param certificateHostName if not null, then true will be iff a certificate with the given templateIdOrName
+	 *                            exists, and it has a host-name matching this parameter
+	 * @return
+	 */
+	public boolean certificateExists(String templateIdOrName, String certificateHostName) {
+		Fragment response = getCertificatesForTemplate(templateIdOrName);
+		return certificateHostName != null ?
+			response.elementExists(format("/msec:certificate-list/msec:certificate[msec:host-name = '%s']", certificateHostName)) :
+			response.elementExists("/msec:certificate-list/msec:certificate");
 	}
 
     public Fragment getCertificatesForTemplate(String templateIdOrName) {

--- a/src/test/java/com/marklogic/appdeployer/command/security/InsertHostCertificateTest.java
+++ b/src/test/java/com/marklogic/appdeployer/command/security/InsertHostCertificateTest.java
@@ -13,9 +13,23 @@ import java.util.List;
 public class InsertHostCertificateTest extends AbstractAppDeployerTest {
 
 	private final static String TEMPLATE_NAME = "sample-app-certificate-template";
+	private final static String CERTIFICATE_HOSTNAME = "host1.marklogic.com";
 
 	@Test
-	public void test() {
+	public void getCertificateHostName() {
+		InsertCertificateHostsTemplateCommand command = new InsertCertificateHostsTemplateCommand();
+
+		assertEquals(
+			"When the filename ends in .crt, the rest of the filename is assumed to be the hostname",
+			"example", command.getCertificateHostName(new File("example.crt")));
+
+		assertNull(
+			"If the filename does not end in .crt, then null should be returned, as it's thus not known what the hostname should be",
+			command.getCertificateHostName(new File("example.pem")));
+	}
+
+	@Test
+	public void insertCertificateAndVerify() {
 		appConfig.setConfigDir(new ConfigDir(new File("src/test/resources/sample-app/host-certificates")));
 
 		initializeAppDeployer(
@@ -49,7 +63,27 @@ public class InsertHostCertificateTest extends AbstractAppDeployerTest {
 		assertTrue(templateNames.contains(TEMPLATE_NAME));
 
 		Fragment xml = mgr.getCertificatesForTemplate(TEMPLATE_NAME);
-		assertEquals("host1.marklogic.com", xml.getElementValue("/msec:certificate-list/msec:certificate/msec:host-name"));
+		assertEquals(CERTIFICATE_HOSTNAME, xml.getElementValue("/msec:certificate-list/msec:certificate/msec:host-name"));
 		assertEquals("MarkLogicBogusCA", xml.getElementValue("/msec:certificate-list/msec:certificate/cert:cert/cert:issuer/cert:commonName"));
+
+		verifyCommandThinksTheCertificateExists(mgr);
+	}
+
+	private void verifyCommandThinksTheCertificateExists(CertificateTemplateManager mgr) {
+		InsertCertificateHostsTemplateCommand command = new InsertCertificateHostsTemplateCommand();
+
+		assertTrue(
+			"Since matching on hostname is disabled by default, then the command should return true regardless of what the filename is",
+			command.certificateExists(TEMPLATE_NAME, new File("anything.crt"), mgr));
+
+		// Now turn on matching and verify
+		command.setMatchCertificateOnHostName(true);
+		assertTrue(command.certificateExists(TEMPLATE_NAME, new File(CERTIFICATE_HOSTNAME + ".crt"), mgr));
+		assertFalse(
+			"A match won't be found here because the filename doesn't end with .crt",
+			command.certificateExists(TEMPLATE_NAME, new File(CERTIFICATE_HOSTNAME + ".pem"), mgr));
+		assertFalse(
+			"A match won't be found here because the filename doesn't start with the hostname",
+			command.certificateExists(TEMPLATE_NAME, new File("something.crt"), mgr));
 	}
 }


### PR DESCRIPTION
Steve - try this out locally. The one catch is that you'll need to manually call the new setMatch... method on the Command. 

I am open to adding a new ml* property here to simplify this. I wasn't sure about a nice name - I was thinking "mlMatchHostCertificatesOnHostName". That's a mouthful, but I think it's important to have the word "HostCertificate" in there to give it context. 